### PR TITLE
Use the 'version' number (obtained from mod.txt) instead of 'hash' within meta.json

### DIFF
--- a/.github/meta.json
+++ b/.github/meta.json
@@ -1,7 +1,7 @@
 [
     {
         "ident" : "pd2_sample_autoupdate",
-        "hash" : "%HASH%",
+        "version" : "%VERSION%",
         "patchnotes_url" : "https://example.com/other-patchnotes.html",
         "download_url" : "https://github.com/HugoZink/PD2AutoUpdateExample/releases/download/refs%2Fheads%2Fmaster/pd2autoupdatexample.zip"
     }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,6 @@ jobs:
         filename: "./SampleMod/mod.txt"
         # The prefix for variables.
         prefix: "mod"
-
     - name: Update version number in meta file
       id: create_meta_file_v2
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,21 @@ jobs:
         asset_path: ./pd2autoupdatexample.zip
         asset_name: pd2autoupdatexample.zip
         asset_content_type: application/zip
-    - name: Hash mod and create mod meta file
-      id: create_meta_file
+    - name: JSON to variables
+      # see https://github.com/antifree/json-to-variables
+      # You may pin to the exact commit or the version.
+      # uses: antifree/json-to-variables@cc8c6394031e145c90f7f9ec909d83df92431fb8
+      uses: antifree/json-to-variables@v1.0.1
+      with:
+        # The json file.
+        filename: "./SampleMod/mod.txt"
+        # The prefix for variables.
+        prefix: "mod"
+
+    - name: Update version number in meta file
+      id: create_meta_file_v2
       run: |
-         $(cat .\.github\meta.json).Replace("%HASH%", $(./.github/hash.exe "./SampleMod").Substring(17)) > ./meta.json
+        $(cat .\.github\meta.json).Replace("%VERSION%", ${{ env.mod_version }}) > ./meta.json
     - name: Upload meta file to Release
       id: upload-meta-asset 
       uses: actions/upload-release-asset@v1

--- a/README.md
+++ b/README.md
@@ -6,21 +6,16 @@ Download or clone this repo. Copy the entire .github folder to your own project'
 For the simplest configuration, simply change `SampleMod` in release.yml to point to your mod's root folder, and change `pd2autoupdatexample.zip` to a more personal zip name that will be used for your mod's zip files.
 Don't forget to change the `ident` field in meta.json to your own mod's ID!
 
-This template needs your mod's main folder to be *under* your repository's root. If your mod.txt file is inside the root of the repository, the hash checks won't function properly anymore, so move the mod into a child folder.
+This template needs your mod's main folder to be *under* your repository's root. If your mod.txt file is inside the root of the repository, it won't be included in the zipped-up mod, so move the mod into a child folder.
 
 After you modify meta.json and releases.yml to match your own mod's ID and zip names, you are ready to commit and push. On your first push *or* your first pull request towards master, Github should immediately start performing all actions.
 This action will delete any existing releases and make a new one, where it will upload your mod's zip file and meta.json. **Remember that the default behavior is to haphazardly delete any other releases or tags in the Releases section.**
 
 Copy the direct download link for your mod's zip, and put it inside `.github/meta.json`. Copy the direct download link for your release's meta.json file, and put it in the updates section of your mod.txt file.
 
-Commit and push these changes again, and your mod should be ready to go! Any pushes to master will immediately be zipped and made available to users ingame. Github will zip your mod for you and calculate a new hash.
-
-# Dealing with line endings
-Line endings may or may not (probably not) negatively affect the way the hashing works, which might endlessly pester your users with non-existent updates.
-If this happens to you, copy the provided `.gitattributes` file into your own repository to prevent Git from messing with your line endings.
+Commit and push these changes again, and your mod should be ready to go! Any pushes to master will immediately be zipped and made available to users ingame. Github will zip your mod for you, and update the meta.json version number based on your mod.txt version number
 
 # Misc Info
-The included SuperBLT hash calculator was made by fragtrane: https://github.com/fragtrane/Python-SuperBLT-Hash-Calculator
 7-Zip by Igor Pavlov: https://www.7-zip.org/
 
 7-zip is included and has to be used because SuperBLT's unzipper is incompatible with Powershell's `Compress-Archive` or the `tar` command.

--- a/SampleMod/mod.txt
+++ b/SampleMod/mod.txt
@@ -3,7 +3,7 @@
 	"description" : "An example mod that only exists to showcase Github auto-updates with SuperBLT.",
 	"author" : "Rokk",
 	"contact" : "Rokk#8740",
-	"version" : "1.1",
+	"version" : "1.2",
 	"blt_version" : 2,
 	"color" : "255 0 255",
 	"updates" : [


### PR DESCRIPTION
Basically, instead of using a hash, it uses a version number (read from mod.txt). Even though it's not fully documented in the official documentation, it still says that 

> the version entry ... generally should be used instead of the hash entry.

(see https://superblt.znix.xyz/doc/updates/).